### PR TITLE
Implemented unhandled exception handling

### DIFF
--- a/ManicDigger/Program.cs
+++ b/ManicDigger/Program.cs
@@ -22,8 +22,13 @@ using OpenTK.Graphics;
         [STAThread]
         public static void Main(string[] args)
         {
+            //Catch unhandled exceptions
+            CrashReporter.DefaultFileName = "ManicDiggerClientCrash.txt";
+            CrashReporter.EnableGlobalExceptionHandling(false);
+
             new ManicDiggerProgram(args);
         }
+
         public ManicDiggerProgram(string[] args)
         {
             dummyNetwork = new DummyNetwork();

--- a/ManicDiggerLib/ClientNative/Misc.cs
+++ b/ManicDiggerLib/ClientNative/Misc.cs
@@ -10,6 +10,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Xml.XPath;
 using System.Xml;
+using System.Threading;
 
 namespace ManicDigger.ClientNative
 {
@@ -82,7 +83,79 @@ namespace ManicDigger.ClientNative
     }
     public class CrashReporter
     {
-        public void Start(System.Threading.ThreadStart start)
+        private static string gamepathcrash = GameStorePath.GetStorePath();
+        private static string s_strDefaultFileName = "ManicDiggerCrash.txt";
+
+        private string m_strFileName = "";
+
+        public Action OnCrash;
+
+        /// <summary>
+        /// If set to true, the crash will be written to the console.
+        /// If set to false, the crash will be displayed in a MessageBox.
+        /// </summary>
+        private static bool s_blnIsConsole = false;
+
+        /// <summary>
+        /// Default filename for crash reports
+        /// </summary>
+        public static string DefaultFileName
+        {
+            get { return s_strDefaultFileName; }
+            set { s_strDefaultFileName = value; }
+        }
+
+        /// <summary>
+        /// Writes crashreport to the file specified in DefaultFileName
+        /// </summary>
+        public CrashReporter() : 
+            this(s_strDefaultFileName)
+        {
+        }
+
+        /// <summary>
+        /// Writes crashreport to the given filename
+        /// </summary>
+        /// <param name="strFileName">Filename for the CrashReport</param>
+        public CrashReporter(string strFileName)
+        {
+            m_strFileName = strFileName;
+        }
+
+        /// <summary>
+        /// Enable global Exception handlin
+        /// </summary>
+        /// <param name="blnIsConsole">If set to true, the crash will be written to the console. If set to false, the crash will be displayed in a MessageBox.</param>
+        public static void EnableGlobalExceptionHandling(bool blnIsConsole)
+        {
+            s_blnIsConsole = blnIsConsole;
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+        }
+
+        /// <summary>
+        /// Called after a unhandled exception occured
+        /// </summary>
+        static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            if (s_blnIsConsole)
+            {
+                //Critical!
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.Out.WriteLine("Unhandled Exception occured");
+            }
+
+            Exception ex = e.ExceptionObject as Exception;
+
+            //Create CrashReport for exception
+            CrashReporter reporter = new CrashReporter();
+            reporter.Crash(ex);
+        }
+
+        /// <summary>
+        /// Creates a CrashReport if the Action failed
+        /// </summary>
+        /// <param name="start">Action to execute</param>
+        public void Start(ThreadStart start)
         {
             if (!Debugger.IsAttached)
             {
@@ -100,37 +173,131 @@ namespace ManicDigger.ClientNative
                 start();
             }
         }
-        public static string gamepathcrash = GameStorePath.GetStorePath();
-        public void Crash(Exception e)
+        
+
+        /// <summary>
+        /// Log the exception and exit the application
+        /// </summary>
+        public void Crash(Exception exCrash)
         {
-            if (!Directory.Exists(gamepathcrash))
-            {
-                Directory.CreateDirectory(gamepathcrash);
-            }
-            string crashfile = Path.Combine(gamepathcrash, "ManicDiggerCrash.txt");
-            File.WriteAllText(crashfile, e.ToString());
-            Console.WriteLine(e);
-            if (OnCrash != null)
-            {
-                OnCrash();
-            }
+            StringBuilder strGuiMessage = new StringBuilder();
+
+            strGuiMessage.AppendLine(DateTime.Now.ToString() + "> Critical Error: " + exCrash.Message);
+
+            //Write to Crash.txt
             try
             {
-                for (int i = 0; i < 5; i++)
+                if (!Directory.Exists(gamepathcrash))
                 {
-                    System.Windows.Forms.Cursor.Show();
-                    System.Threading.Thread.Sleep(100);
-                    Application.DoEvents();
+                    Directory.CreateDirectory(gamepathcrash);
                 }
-                System.Windows.Forms.MessageBox.Show(e.ToString());
+
+                string crashfile = Path.Combine(gamepathcrash, m_strFileName);
+
+                //Open/Create Crash file
+                using (FileStream fs = File.Open(crashfile, FileMode.Append))
+                {
+                    using (StreamWriter logger = new StreamWriter(fs))
+                    {
+                        Log(DateTime.Now.ToString() + ": Critical error occured", logger);
+
+                        //Call OnCrash logic
+                        CallOnCrash(logger);
+
+                        Exception exToLog = exCrash;
+
+                        //Log the exception and its inner exceptions
+                        while (exToLog != null)
+                        {
+                            Log(exToLog.ToString(), logger);
+                            Log("-------------------------------", logger);
+                            exToLog = exToLog.InnerException;
+                        }
+                    }
+                }
+
+                //Output Crashreport Location
+                strGuiMessage.AppendLine("Crash report created: \"" + crashfile + "\"");
             }
-            catch (Exception ee)
+            catch (Exception ex)
             {
-                Console.WriteLine(ee.ToString());
+                strGuiMessage.AppendLine("Crashreport failed: " + ex.ToString());
             }
-            Environment.Exit(1);
+            finally
+            {
+                DisplayInGui(strGuiMessage.ToString());
+
+                if (s_blnIsConsole)
+                {
+                    //Give user time to read output
+                    Console.WriteLine("Ending after critical error!");
+                    Console.WriteLine("Press any key to shut down...");
+                    Console.ReadLine();
+                }
+
+                //Shutdown
+                Environment.Exit(1);
+            }
         }
-        public Action OnCrash;
+
+        /// <summary>
+        /// Tries to execute the OnCrash delegate
+        /// </summary>
+        private void CallOnCrash(TextWriter logger)
+        {
+            if (OnCrash != null)
+            {
+                try
+                {
+                    OnCrash();
+                }
+                catch (Exception ex)
+                {
+                    logger.WriteLine("OnCrash() failed: " + ex.ToString());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Write to logger and Console
+        /// </summary>
+        private void Log(string str, TextWriter logger)
+        {
+            logger.WriteLine(str);
+            Console.WriteLine(str);
+        }
+
+        /// <summary>
+        /// Displays a text in the gui
+        /// </summary>
+        private void DisplayInGui(string strTxt)
+        {
+            try
+            {
+                //Display error
+                if (!s_blnIsConsole)
+                {
+                    for (int i = 0; i < 5; i++)
+                    {
+                        Cursor.Show();
+                        Thread.Sleep(100);
+                        Application.DoEvents();
+                    }
+
+                    MessageBox.Show(strTxt, "Critical error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+                else
+                {
+                    Console.WriteLine(strTxt);
+                }
+            }
+            catch (Exception ex)
+            {
+                //If this fails, something is really screwed... let's hope the crash report was created
+                //Just swallow this exception, to prevent a exception endless loop (UnhandledException -> CrashReport -> UnhandledException)
+            }
+        }
+        
     }
 
     public static class GameStorePath

--- a/ManicDiggerServer/Program.cs
+++ b/ManicDiggerServer/Program.cs
@@ -12,24 +12,28 @@ namespace ManicDiggerServer
     {
         static void Main(string[] args)
         {
+            //Catch unhandled exceptions
+            CrashReporter.DefaultFileName = "ManicDiggerServerCrash.txt";
+            CrashReporter.EnableGlobalExceptionHandling(true);
+
             new Program(args);
         }
         
         public Program(string[] args)
         {
+            //TODO: Check if file exists
             try
             {
-                using (Stream s = new MemoryStream(File.ReadAllBytes(Path.Combine(GameStorePath.gamepathconfig, "ServerConfig.txt"))))
+                using (FileStream stream = File.Open(Path.Combine(GameStorePath.gamepathconfig, "ServerConfig.txt"), FileMode.Open))
                 {
-                    StreamReader sr = new StreamReader(s);
                     XmlDocument d = new XmlDocument();
-                    d.Load(sr);
+                    d.Load(stream);
                     autoRestartCycle = int.Parse(XmlTool.XmlVal(d, "/ManicDiggerServerConfig/AutoRestartCycle"));
                 }
             }
             catch
             {
-                //ServerConfig cannot be read. Use default value of 6 hours
+                Console.WriteLine("ServerConfig cannot be read. Use default value of 6 hours");
                 autoRestartCycle = 6;
             }
             


### PR DESCRIPTION
Hi,
I changed the CrashReporter a bit.
Open for discussion  :)

You can now use "**CrashReporter.EnableGlobalExceptionHandling(bool)**" to enable global exception handling. This will create a CrashReport as soon as a UnhandledException occures.

Other changes:
- On a crash, the messagebox will only be shown, if the application is not running in console mode.
- Existing CrashReports are no longer overwritten, instead the new report will be appenden to the existing.
- The CrashReporte filename can now be changed by the caller.
