### PR TITLE
Using localization for move speed

### DIFF
--- a/ManicDiggerLib/Client/Game.ci.cs
+++ b/ManicDiggerLib/Client/Game.ci.cs
@@ -3339,7 +3339,7 @@
                     return;
                 }
                 movespeed = basemovespeed * 1;
-                Log("Move speed: 1x.");
+                Log(platform.StringFormat(language.MoveSpeed(), platform.IntToString(1)));
             }
             if (eKey == GetKey(GlKeys.F2))
             {


### PR DESCRIPTION
I just played a round today and it just bugged me that he localization wasn't used for "Move Speed 1x". This is a simple fix.